### PR TITLE
runDataFrameFinal.py can save the results to a .txt-file

### DIFF
--- a/config/runDataFrameFinal.py
+++ b/config/runDataFrameFinal.py
@@ -195,13 +195,14 @@ class runDataFrameFinal():
 
             for i, cut in enumerate(self.cuts):
                 neventsThisCut = count_list[i].GetValue()
+                neventsThisCut_raw = neventsThisCut
                 if doScale:
                     neventsThisCut = neventsThisCut*1.*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                 print ('       After selection {cutname:{width}} : {nevents:.2e}'.format(cutname=cut, width=length_cuts_names, nevents=neventsThisCut))
 
                 # Saving the number of events, uncertainty and efficiency for the output-file
                 if saveTabular:
-                    uncertainty = ROOT.Math.sqrt(neventsThisCut)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
+                    uncertainty = ROOT.Math.sqrt(neventsThisCut_raw)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                     if neventsThisCut != 0:
                         cuts_list.append('{nevents:.2e} \\pm {uncertainty:.2e}'.format(nevents=neventsThisCut,uncertainty=uncertainty))
                         prevNevents = cuts_list[-2].split()

--- a/config/runDataFrameFinal.py
+++ b/config/runDataFrameFinal.py
@@ -190,7 +190,8 @@ class runDataFrameFinal():
             print ('       {cutname:{width}} : {nevents:.2e}'.format(cutname='All events', width=16+length_cuts_names, nevents=all_events))
 
             if saveTabular:
-                cuts_list.append('{all_events:.2e}'.format(all_events=all_events))
+                uncertainty = ROOT.Math.sqrt(nevents_real)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
+                cuts_list.append('{nevents:.2e} $\\pm$ {uncertainty:.2e}'.format(nevents=all_events,uncertainty=uncertainty))
                 eff_list.append(1)
 
             for i, cut in enumerate(self.cuts):
@@ -204,13 +205,13 @@ class runDataFrameFinal():
                 if saveTabular:
                     uncertainty = ROOT.Math.sqrt(neventsThisCut_raw)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                     if neventsThisCut != 0:
-                        cuts_list.append('{nevents:.2e} \\pm {uncertainty:.2e}'.format(nevents=neventsThisCut,uncertainty=uncertainty))
+                        cuts_list.append('{nevents:.2e} $\\pm$ {uncertainty:.2e}'.format(nevents=neventsThisCut,uncertainty=uncertainty))
                         prevNevents = cuts_list[-2].split()
                         eff_list.append('{:.2e}'.format(neventsThisCut/float(prevNevents[0])))
                     # if number of events is zero, the previous uncertainty is saved instead:
-                    elif '\\pm' in cuts_list[-1]:
+                    elif '$\\pm$' in cuts_list[-1]:
                         cut = (cuts_list[-1]).split()
-                        cuts_list.append('\\leq {uncertainty}'.format(uncertainty=cut[2]))
+                        cuts_list.append('$\\leq$ {uncertainty}'.format(uncertainty=cut[2]))
                         eff_list.append(1)
                     else:
                         cuts_list.append(cuts_list[-1])
@@ -242,7 +243,7 @@ class runDataFrameFinal():
                 efficiencyList.append(eff_list)
         if saveTabular:
             # Printing the number of events in format of a LaTeX table
-            print('\\begin{table}[H] \n    \\centering \n    \\begin{tabular}{|l||',end='',file=f)
+            print('\\begin{table}[H] \n    \\centering \n    \\resizebox{\\textwidth}{!}{ \n    \\begin{tabular}{|l||',end='',file=f)
             print('c|' * (len(saveTab)-1),end='',file=f)
             print('} \hline',file=f)
             for i in range(len(cuts_list)):
@@ -250,7 +251,9 @@ class runDataFrameFinal():
                 print('        ', end='', file=f)
                 print(*v, sep = ' & ', end='', file=f)
                 print(' \\\\ ', file=f)
-            print('        \\hline \n    \\end{tabular} \n    \\caption{Caption} \n    \\label{tab:my_label} \n\\end{table}', file=f)
+                if (i == 0):
+                    print('        \\hline',file=f)
+            print('        \\hline \n    \\end{tabular}} \n    \\caption{Caption} \n    \\label{tab:my_label} \n\\end{table}', file=f)
             
             # Efficiency:
             print('\n\nEfficiency: ', file=f)

--- a/config/runDataFrameFinal.py
+++ b/config/runDataFrameFinal.py
@@ -129,7 +129,7 @@ class runDataFrameFinal():
             f = open("outputTabular.txt","w")
             cutNames = [cut for cut in self.cuts]
             cutNames.insert(0,'All events')
-            cutNames.insert(0,'Proscesses')
+            cutNames.insert(0,'Processes')
             saveTab.append(cutNames)
             efficiencyList.append(cutNames)
 

--- a/config/runDataFrameFinal.py
+++ b/config/runDataFrameFinal.py
@@ -198,12 +198,15 @@ class runDataFrameFinal():
                 if doScale:
                     neventsThisCut = neventsThisCut*1.*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                 print ('       After selection {cutname:{width}} : {nevents:.2e}'.format(cutname=cut, width=length_cuts_names, nevents=neventsThisCut))
+
+                # Saving the number of events, uncertainty and efficiency for the output-file
                 if saveTabular:
                     uncertainty = ROOT.Math.sqrt(neventsThisCut)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                     if neventsThisCut != 0:
                         cuts_list.append('{nevents:.2e} \\pm {uncertainty:.2e}'.format(nevents=neventsThisCut,uncertainty=uncertainty))
                         prevNevents = cuts_list[-2].split()
                         eff_list.append('{:.2e}'.format(neventsThisCut/float(prevNevents[0])))
+                    # if number of events is zero, the previous uncertainty is saved instead:
                     elif '\\pm' in cuts_list[-1]:
                         cut = (cuts_list[-1]).split()
                         cuts_list.append('\\leq {uncertainty}'.format(uncertainty=cut[2]))
@@ -237,7 +240,7 @@ class runDataFrameFinal():
                 saveTab.append(cuts_list)
                 efficiencyList.append(eff_list)
         if saveTabular:
-            # Printing the results in format of a LaTeX table
+            # Printing the number of events in format of a LaTeX table
             print('\\begin{table}[H] \n    \\centering \n    \\begin{tabular}{|l||',end='',file=f)
             print('c|' * (len(saveTab)-1),end='',file=f)
             print('} \hline',file=f)

--- a/config/runDataFrameFinal.py
+++ b/config/runDataFrameFinal.py
@@ -51,7 +51,7 @@ class runDataFrameFinal():
             return False
         return True
     #__________________________________________________________
-    def run(self,ncpu=5,doTree=False,doScale=True):
+    def run(self,ncpu=5,doTree=False,doScale=True,saveTabular=False):
         print ("EnableImplicitMT: {}".format(ncpu))
         ROOT.ROOT.EnableImplicitMT(ncpu)
         print ("Load cxx analyzers ... ")
@@ -65,6 +65,8 @@ class runDataFrameFinal():
         processEvents={}
         eventsTTree={}
         processList={}
+        saveTab=[]
+        efficiencyList=[]
         
         for pr in self.processes:
             processEvents[pr]=0
@@ -123,9 +125,16 @@ class runDataFrameFinal():
 
         length_cuts_names = max([len(cut) for cut in self.cuts])
 
+        if saveTabular:
+            f = open("outputTabular.txt","w")
+            cutNames = [cut for cut in self.cuts]
+            cutNames.insert(0,'All events')
+            cutNames.insert(0,'Proscesses')
+            saveTab.append(cutNames)
+            efficiencyList.append(cutNames)
+
         for pr in self.processes:
             print ('\n   running over process : ',pr)
-
             RDF = ROOT.ROOT.RDataFrame
             df  = RDF(self.treename, processList[pr] )
             if len(self.defines)>0:
@@ -137,6 +146,10 @@ class runDataFrameFinal():
             histos_list = []
             tdf_list = []
             count_list = []
+            cuts_list = []
+            cuts_list.append(pr)
+            eff_list=[]
+            eff_list.append(pr)
 
             # Define all histos, snapshots, etc...
             print ('     Defining snapshots and histograms')
@@ -175,11 +188,29 @@ class runDataFrameFinal():
 
             print ('     Cutflow')
             print ('       {cutname:{width}} : {nevents:.2e}'.format(cutname='All events', width=16+length_cuts_names, nevents=all_events))
+
+            if saveTabular:
+                cuts_list.append('{all_events:.2e}'.format(all_events=all_events))
+                eff_list.append(1)
+
             for i, cut in enumerate(self.cuts):
                 neventsThisCut = count_list[i].GetValue()
                 if doScale:
                     neventsThisCut = neventsThisCut*1.*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
                 print ('       After selection {cutname:{width}} : {nevents:.2e}'.format(cutname=cut, width=length_cuts_names, nevents=neventsThisCut))
+                if saveTabular:
+                    uncertainty = ROOT.Math.sqrt(neventsThisCut)*self.procDict[pr]["crossSection"]*self.procDict[pr]["kfactor"]*self.procDict[pr]["matchingEfficiency"]*self.intLumi/eventsTTree[pr]
+                    if neventsThisCut != 0:
+                        cuts_list.append('{nevents:.2e} \\pm {uncertainty:.2e}'.format(nevents=neventsThisCut,uncertainty=uncertainty))
+                        prevNevents = cuts_list[-2].split()
+                        eff_list.append('{:.2e}'.format(neventsThisCut/float(prevNevents[0])))
+                    elif '\\pm' in cuts_list[-1]:
+                        cut = (cuts_list[-1]).split()
+                        cuts_list.append('\\leq {uncertainty}'.format(uncertainty=cut[2]))
+                        eff_list.append(1)
+                    else:
+                        cuts_list.append(cuts_list[-1])
+                        eff_list.append(1)
 
 
             # And save everything
@@ -202,6 +233,27 @@ class runDataFrameFinal():
                     validfile = self.testfile(fout_list[i])
                     if not validfile: continue
 
+            if saveTabular:
+                saveTab.append(cuts_list)
+                efficiencyList.append(eff_list)
+        if saveTabular:
+            # Printing the results in format of a LaTeX table
+            print('\\begin{table}[H] \n    \\centering \n    \\begin{tabular}{|l||',end='',file=f)
+            print('c|' * (len(saveTab)-1),end='',file=f)
+            print('} \hline',file=f)
+            for i in range(len(cuts_list)):
+                v = [row[i] for row in saveTab]
+                print('        ', end='', file=f)
+                print(*v, sep = ' & ', end='', file=f)
+                print(' \\\\ ', file=f)
+            print('        \\hline \n    \\end{tabular} \n    \\caption{Caption} \n    \\label{tab:my_label} \n\\end{table}', file=f)
+            
+            # Efficiency:
+            print('\n\nEfficiency: ', file=f)
+            for i in range(len(eff_list)):
+                v = [row[i] for row in efficiencyList]
+                print(*v, sep = ' & ', file=f)
+            f.close()
 
         elapsed_time = time.time() - start_time
         print  ('==============================SUMMARY==============================')


### PR DESCRIPTION
Changes in runDataFrameFinal:
- Uses the option saveTabular in run() to save the results in a .txt-file called 'outputTabular.txt' in format of a LaTeX-tabular. 
- Saves the number of events (scaled) with given uncertainty. If number of events is zero, the previous uncertainty is given.
- Begun work on saving the efficiency, currently it is comparing current number of events with the previous selection

**Note:** For proper results in the .txt-file the given cuts for self.cuts should be given in the desired order of selections on top of each other.